### PR TITLE
feat: improve CLI execution result formatting

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import { ConnectionPool } from './connection-pool.js';
 import { RateLimiter } from './rate-limiter.js';
 import { executeTypescriptInSandbox } from './sandbox-executor.js';
 import { executePythonInSandbox } from './python-executor.js';
-import { formatErrorResponse } from './utils.js';
+import { formatErrorResponse, formatExecutionResultForCli } from './utils.js';
 import { ErrorType } from './types.js';
 import { checkDenoAvailable, getDenoVersion, getDenoInstallMessage } from './deno-checker.js';
 import { HealthCheckServer } from './health-check.js';
@@ -279,7 +279,7 @@ Example:
           return {
             content: [{
               type: 'text' as const,
-              text: JSON.stringify(result, null, 2),
+              text: formatExecutionResultForCli(result),
             }],
             structuredContent: result as MCPExecutionResult,
             isError: !result.success,
@@ -435,7 +435,7 @@ Example:
             return {
               content: [{
                 type: 'text' as const,
-                text: JSON.stringify(result, null, 2),
+                text: formatExecutionResultForCli(result),
               }],
               structuredContent: result as MCPExecutionResult,
               isError: !result.success,


### PR DESCRIPTION
## Summary
- add a CLI formatter that renders execution results with sectioned output and optional ANSI styling
- update TypeScript and Python tool handlers to emit formatted human-readable text while keeping structured payloads
- add unit tests covering success, failure, timeout, and ANSI styling scenarios

## Testing
- npx vitest run tests/utils.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69164ff2f1e8832a8b810a2c532d3cba)