### PR TITLE
fix: allow hyphens in MCP server names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3751,6 +3751,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -51,7 +51,7 @@ export function formatErrorResponse(
 export function isValidMCPToolName(toolName: string): boolean {
   // Format: mcp__<server>__<tool>
   // Allow uppercase (Linear, Notion), hyphens (Context7 tools), and underscores
-  const pattern = /^mcp__[a-zA-Z0-9_]+__[a-zA-Z0-9_-]+$/;
+  const pattern = /^mcp__[a-zA-Z0-9_-]+__[a-zA-Z0-9_-]+$/;
   return pattern.test(toolName);
 }
 

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -141,10 +141,11 @@ describe('isValidMCPToolName', () => {
     expect(isValidMCPToolName('mcp__zen__code-review')).toBe(true);
   });
 
-  it('should_reject_hyphens_in_server_names', () => {
-    // Hyphens NOT allowed in server names
-    expect(isValidMCPToolName('mcp__zen-test__codereview')).toBe(false);
-    expect(isValidMCPToolName('mcp__my-server__tool')).toBe(false);
+  it('should_accept_hyphens_in_server_names', () => {
+    // Hyphens are allowed in server names (fixes #62)
+    expect(isValidMCPToolName('mcp__code-executor__run-typescript-code')).toBe(true);
+    expect(isValidMCPToolName('mcp__figma-context__get_figma_data')).toBe(true);
+    expect(isValidMCPToolName('mcp__chrome-devtools__click')).toBe(true);
   });
 
   it('should_reject_unsupported_special_characters', () => {


### PR DESCRIPTION
Fixes #62

## Summary

The validation regex was rejecting server names with hyphens, preventing valid tools like `mcp__code-executor__*` (this package's own tools), `mcp__figma-context__*`, and `mcp__chrome-devtools__*` from being used in the `allowedTools` parameter.

## Changes

- Updated regex pattern in `src/utils.ts:54` to allow hyphens in server names
- Updated test case to verify hyphens are now accepted in server names
- Matches documented intention in code comment (line 53)

## Testing

All tests pass (38/38):
```bash
npm test -- --run tests/utils.test.ts
```

New test cases verify:
- ✅ `mcp__code-executor__run-typescript-code`
- ✅ `mcp__figma-context__get_figma_data`
- ✅ `mcp__chrome-devtools__click`

## Backward Compatibility

✅ This change is backward compatible - it only expands what's accepted, not restricts it.

## Related

See issue #62 for detailed analysis including README example that would fail validation.