### PR TITLE
feat: add excludeServers config option to filter MCP servers

### DIFF
--- a/src/mcp/client-pool.ts
+++ b/src/mcp/client-pool.ts
@@ -157,6 +157,7 @@ export class MCPClientPool implements IToolSchemaProvider {
         console.error(`📂 Merging ${configPaths.length} MCP configs: ${configPaths.map(p => p.split('/').pop()).join(' → ')}`);
 
         const mergedServers: Record<string, MCPServerConfig> = {};
+        const mergedExcludeServers: Set<string> = new Set();
 
         for (const configPath of configPaths) {
           try {
@@ -165,6 +166,13 @@ export class MCPClientPool implements IToolSchemaProvider {
 
             // Merge mcpServers (later configs override earlier)
             Object.assign(mergedServers, parsedConfig.mcpServers || {});
+
+            // Accumulate excludeServers from all configs (union, not override)
+            if (Array.isArray(parsedConfig.excludeServers)) {
+              for (const name of parsedConfig.excludeServers) {
+                mergedExcludeServers.add(name);
+              }
+            }
           } catch (error) {
             // TYPE-001 fix: Use normalizeError for consistency
             const err = normalizeError(error);
@@ -172,15 +180,35 @@ export class MCPClientPool implements IToolSchemaProvider {
           }
         }
 
-        config = { mcpServers: mergedServers };
+        config = {
+          mcpServers: mergedServers,
+          ...(mergedExcludeServers.size > 0 && { excludeServers: [...mergedExcludeServers] }),
+        };
       }
 
-      // Filter out code-executor to prevent circular dependency
+      // Build exclusion set: always exclude self + user-configured exclusions + env var
+      const excludeSet = new Set<string>(['code-executor']);
+      if (config.excludeServers) {
+        for (const name of config.excludeServers) {
+          excludeSet.add(name);
+        }
+      }
+      const envExclude = process.env.EXCLUDE_MCP_SERVERS;
+      if (envExclude) {
+        for (const name of envExclude.split(',').map(s => s.trim()).filter(Boolean)) {
+          excludeSet.add(name);
+        }
+      }
+
       const filteredServers = Object.entries(config.mcpServers).filter(
-        ([serverName]) => serverName !== 'code-executor'
+        ([serverName]) => !excludeSet.has(serverName)
       );
 
-      console.error(`🔌 Initializing MCP client pool (excluding self, ${filteredServers.length} servers)`);
+      const userExclusions = [...excludeSet].filter(n => n !== 'code-executor');
+      if (userExclusions.length > 0) {
+        console.error(`🚫 Excluding MCP servers: ${userExclusions.join(', ')}`);
+      }
+      console.error(`🔌 Initializing MCP client pool (excluding self${userExclusions.length > 0 ? ` + ${userExclusions.length} excluded` : ''}, ${filteredServers.length} servers)`);
 
       // Connect to each configured server with detailed error tracking
       const serverNames = filteredServers.map(([name]) => name);

--- a/src/types.ts
+++ b/src/types.ts
@@ -167,6 +167,8 @@ export interface ProcessInfo {
 export interface MCPConfig {
   /** Map of server name to configuration */
   mcpServers: Record<string, MCPServerConfig>;
+  /** Server names to exclude from loading (in addition to self-exclusion) */
+  excludeServers?: string[];
 }
 
 /**

--- a/tests/exclude-servers.test.ts
+++ b/tests/exclude-servers.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Tests for excludeServers config option
+ *
+ * Validates that servers can be excluded from loading via:
+ * 1. Config-driven: `excludeServers` field in MCP config JSON
+ * 2. Environment variable: `EXCLUDE_MCP_SERVERS` (comma-separated)
+ * 3. Union semantics: multiple config files accumulate exclusions
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Mock modules BEFORE imports
+vi.mock('fs/promises');
+vi.mock('../src/config/loader.js');
+
+import * as fs from 'fs/promises';
+import { MCPClientPool } from '../src/mcp/client-pool.js';
+import * as loader from '../src/config/loader.js';
+
+describe('excludeServers', () => {
+  let pool: MCPClientPool;
+  let connectSpy: ReturnType<typeof vi.fn>;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    originalEnv = { ...process.env };
+    delete process.env.EXCLUDE_MCP_SERVERS;
+
+    // Mock getPoolConfig so the constructor doesn't fail
+    vi.mocked(loader.getPoolConfig).mockReturnValue({
+      maxConcurrent: 100,
+      queueSize: 200,
+      queueTimeoutMs: 30000,
+    });
+
+    pool = new MCPClientPool();
+
+    // Prevent real connections and tool caching
+    connectSpy = vi.fn().mockResolvedValue(undefined);
+    vi.spyOn(pool as any, 'connectToServer').mockImplementation(connectSpy);
+    vi.spyOn(pool as any, 'cacheToolListings').mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.clearAllMocks();
+  });
+
+  describe('config-driven exclusion', () => {
+    it('should_excludeServer_when_listedInExcludeServers', async () => {
+      const config = JSON.stringify({
+        mcpServers: {
+          xcode: { command: 'xcode-mcp', args: [] },
+          zen: { command: 'zen-mcp', args: [] },
+        },
+        excludeServers: ['xcode'],
+      });
+
+      vi.mocked(loader.getAllMCPConfigPaths).mockResolvedValue(['/config.json']);
+      vi.mocked(fs.readFile).mockResolvedValue(config as any);
+
+      await pool.initialize();
+
+      expect(connectSpy).toHaveBeenCalledTimes(1);
+      expect(connectSpy).toHaveBeenCalledWith('zen', expect.any(Object));
+      expect(connectSpy).not.toHaveBeenCalledWith('xcode', expect.any(Object));
+    });
+
+    it('should_excludeMultipleServers_when_multipleListedInExcludeServers', async () => {
+      const config = JSON.stringify({
+        mcpServers: {
+          xcode: { command: 'xcode-mcp', args: [] },
+          slow: { command: 'slow-mcp', args: [] },
+          zen: { command: 'zen-mcp', args: [] },
+        },
+        excludeServers: ['xcode', 'slow'],
+      });
+
+      vi.mocked(loader.getAllMCPConfigPaths).mockResolvedValue(['/config.json']);
+      vi.mocked(fs.readFile).mockResolvedValue(config as any);
+
+      await pool.initialize();
+
+      expect(connectSpy).toHaveBeenCalledTimes(1);
+      expect(connectSpy).toHaveBeenCalledWith('zen', expect.any(Object));
+    });
+
+    it('should_connectAllServers_when_excludeServersMissing', async () => {
+      const config = JSON.stringify({
+        mcpServers: {
+          zen: { command: 'zen-mcp', args: [] },
+          github: { command: 'github-mcp', args: [] },
+        },
+      });
+
+      vi.mocked(loader.getAllMCPConfigPaths).mockResolvedValue(['/config.json']);
+      vi.mocked(fs.readFile).mockResolvedValue(config as any);
+
+      await pool.initialize();
+
+      expect(connectSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should_connectAllServers_when_excludeServersEmpty', async () => {
+      const config = JSON.stringify({
+        mcpServers: {
+          zen: { command: 'zen-mcp', args: [] },
+        },
+        excludeServers: [],
+      });
+
+      vi.mocked(loader.getAllMCPConfigPaths).mockResolvedValue(['/config.json']);
+      vi.mocked(fs.readFile).mockResolvedValue(config as any);
+
+      await pool.initialize();
+
+      expect(connectSpy).toHaveBeenCalledTimes(1);
+      expect(connectSpy).toHaveBeenCalledWith('zen', expect.any(Object));
+    });
+  });
+
+  describe('environment variable exclusion', () => {
+    it('should_excludeServer_when_setInEnvVar', async () => {
+      process.env.EXCLUDE_MCP_SERVERS = 'xcode';
+
+      const config = JSON.stringify({
+        mcpServers: {
+          xcode: { command: 'xcode-mcp', args: [] },
+          zen: { command: 'zen-mcp', args: [] },
+        },
+      });
+
+      vi.mocked(loader.getAllMCPConfigPaths).mockResolvedValue(['/config.json']);
+      vi.mocked(fs.readFile).mockResolvedValue(config as any);
+
+      await pool.initialize();
+
+      expect(connectSpy).toHaveBeenCalledTimes(1);
+      expect(connectSpy).toHaveBeenCalledWith('zen', expect.any(Object));
+    });
+
+    it('should_excludeMultiple_when_commaSeparatedEnvVar', async () => {
+      process.env.EXCLUDE_MCP_SERVERS = 'xcode, slow';
+
+      const config = JSON.stringify({
+        mcpServers: {
+          xcode: { command: 'xcode-mcp', args: [] },
+          slow: { command: 'slow-mcp', args: [] },
+          zen: { command: 'zen-mcp', args: [] },
+        },
+      });
+
+      vi.mocked(loader.getAllMCPConfigPaths).mockResolvedValue(['/config.json']);
+      vi.mocked(fs.readFile).mockResolvedValue(config as any);
+
+      await pool.initialize();
+
+      expect(connectSpy).toHaveBeenCalledTimes(1);
+      expect(connectSpy).toHaveBeenCalledWith('zen', expect.any(Object));
+    });
+
+    it('should_handleWhitespaceAndTrailingComma_when_envVarHasEdgeCases', async () => {
+      process.env.EXCLUDE_MCP_SERVERS = ' xcode , , slow , ';
+
+      const config = JSON.stringify({
+        mcpServers: {
+          xcode: { command: 'xcode-mcp', args: [] },
+          slow: { command: 'slow-mcp', args: [] },
+          zen: { command: 'zen-mcp', args: [] },
+        },
+      });
+
+      vi.mocked(loader.getAllMCPConfigPaths).mockResolvedValue(['/config.json']);
+      vi.mocked(fs.readFile).mockResolvedValue(config as any);
+
+      await pool.initialize();
+
+      expect(connectSpy).toHaveBeenCalledTimes(1);
+      expect(connectSpy).toHaveBeenCalledWith('zen', expect.any(Object));
+    });
+  });
+
+  describe('config + env var union', () => {
+    it('should_excludeBoth_when_configAndEnvVarSetDifferentServers', async () => {
+      process.env.EXCLUDE_MCP_SERVERS = 'slow';
+
+      const config = JSON.stringify({
+        mcpServers: {
+          xcode: { command: 'xcode-mcp', args: [] },
+          slow: { command: 'slow-mcp', args: [] },
+          zen: { command: 'zen-mcp', args: [] },
+        },
+        excludeServers: ['xcode'],
+      });
+
+      vi.mocked(loader.getAllMCPConfigPaths).mockResolvedValue(['/config.json']);
+      vi.mocked(fs.readFile).mockResolvedValue(config as any);
+
+      await pool.initialize();
+
+      expect(connectSpy).toHaveBeenCalledTimes(1);
+      expect(connectSpy).toHaveBeenCalledWith('zen', expect.any(Object));
+    });
+  });
+
+  describe('multi-config merge (union semantics)', () => {
+    it('should_unionExclusions_when_multipleConfigsEachExcludeDifferentServers', async () => {
+      const globalConfig = JSON.stringify({
+        mcpServers: {
+          xcode: { command: 'xcode-mcp', args: [] },
+          slow: { command: 'slow-mcp', args: [] },
+          zen: { command: 'zen-mcp', args: [] },
+        },
+        excludeServers: ['xcode'],
+      });
+
+      const projectConfig = JSON.stringify({
+        mcpServers: {},
+        excludeServers: ['slow'],
+      });
+
+      vi.mocked(loader.getAllMCPConfigPaths).mockResolvedValue([
+        '/global.json',
+        '/project.json',
+      ]);
+      vi.mocked(fs.readFile)
+        .mockResolvedValueOnce(globalConfig as any)
+        .mockResolvedValueOnce(projectConfig as any);
+
+      await pool.initialize();
+
+      // Both xcode and slow excluded (union), only zen remains
+      expect(connectSpy).toHaveBeenCalledTimes(1);
+      expect(connectSpy).toHaveBeenCalledWith('zen', expect.any(Object));
+    });
+
+    it('should_deduplicateExclusions_when_multipleConfigsExcludeSameServer', async () => {
+      const config1 = JSON.stringify({
+        mcpServers: { zen: { command: 'zen-mcp', args: [] } },
+        excludeServers: ['xcode'],
+      });
+      const config2 = JSON.stringify({
+        mcpServers: { xcode: { command: 'xcode-mcp', args: [] } },
+        excludeServers: ['xcode'],
+      });
+
+      vi.mocked(loader.getAllMCPConfigPaths).mockResolvedValue(['/a.json', '/b.json']);
+      vi.mocked(fs.readFile)
+        .mockResolvedValueOnce(config1 as any)
+        .mockResolvedValueOnce(config2 as any);
+
+      await pool.initialize();
+
+      expect(connectSpy).toHaveBeenCalledTimes(1);
+      expect(connectSpy).toHaveBeenCalledWith('zen', expect.any(Object));
+    });
+  });
+
+  describe('self-exclusion preserved', () => {
+    it('should_alwaysExcludeCodeExecutor_when_notInExcludeServers', async () => {
+      const config = JSON.stringify({
+        mcpServers: {
+          'code-executor': { command: 'ce', args: [] },
+          zen: { command: 'zen-mcp', args: [] },
+        },
+      });
+
+      vi.mocked(loader.getAllMCPConfigPaths).mockResolvedValue(['/config.json']);
+      vi.mocked(fs.readFile).mockResolvedValue(config as any);
+
+      await pool.initialize();
+
+      expect(connectSpy).toHaveBeenCalledTimes(1);
+      expect(connectSpy).toHaveBeenCalledWith('zen', expect.any(Object));
+    });
+
+    it('should_handleGracefully_when_codeExecutorExplicitlyInExcludeServers', async () => {
+      const config = JSON.stringify({
+        mcpServers: {
+          'code-executor': { command: 'ce', args: [] },
+          zen: { command: 'zen-mcp', args: [] },
+        },
+        excludeServers: ['code-executor'],
+      });
+
+      vi.mocked(loader.getAllMCPConfigPaths).mockResolvedValue(['/config.json']);
+      vi.mocked(fs.readFile).mockResolvedValue(config as any);
+
+      await pool.initialize();
+
+      expect(connectSpy).toHaveBeenCalledTimes(1);
+      expect(connectSpy).toHaveBeenCalledWith('zen', expect.any(Object));
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should_notError_when_excludingNonExistentServer', async () => {
+      const config = JSON.stringify({
+        mcpServers: {
+          zen: { command: 'zen-mcp', args: [] },
+        },
+        excludeServers: ['nonexistent'],
+      });
+
+      vi.mocked(loader.getAllMCPConfigPaths).mockResolvedValue(['/config.json']);
+      vi.mocked(fs.readFile).mockResolvedValue(config as any);
+
+      await pool.initialize();
+
+      expect(connectSpy).toHaveBeenCalledTimes(1);
+      expect(connectSpy).toHaveBeenCalledWith('zen', expect.any(Object));
+    });
+
+    it('should_handleStandaloneMode_when_allServersExcluded', async () => {
+      const config = JSON.stringify({
+        mcpServers: {
+          xcode: { command: 'xcode-mcp', args: [] },
+        },
+        excludeServers: ['xcode'],
+      });
+
+      vi.mocked(loader.getAllMCPConfigPaths).mockResolvedValue(['/config.json']);
+      vi.mocked(fs.readFile).mockResolvedValue(config as any);
+
+      // Should not throw — standalone mode is valid
+      await expect(pool.initialize()).resolves.not.toThrow();
+      expect(connectSpy).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `excludeServers` optional field to `MCPConfig` interface, allowing users to list MCP server names to skip during initialization
- Supports `EXCLUDE_MCP_SERVERS` environment variable (comma-separated) as an alternative/additional mechanism
- Multiple config files accumulate exclusions with union semantics (not override)
- Hardcoded `code-executor` self-exclusion is preserved

## Usage

In MCP config JSON (`.mcp.json` / `.mcp_ce.json`):
```json
{
  "mcpServers": { ... },
  "excludeServers": ["xcode", "slow-server"]
}
```

Or via environment variable:
```bash
EXCLUDE_MCP_SERVERS=xcode,slow-server
```

## Changes

- `src/types.ts` — Add `excludeServers?: string[]` to `MCPConfig` interface (+2 lines)
- `src/mcp/client-pool.ts` — Extend existing filter logic with Set-based exclusion (~25 lines)
- `tests/exclude-servers.test.ts` — 14 tests covering config, env var, union merge, self-exclusion, and edge cases

## Test plan

- [x] 14/14 new tests pass (`vitest run tests/exclude-servers.test.ts`)
- [x] Existing MCP client pool tests unaffected (9/9 pass)
- [x] Manual verification: `EXCLUDE_MCP_SERVERS=xcode` correctly filters server, log shows `🚫 Excluding MCP servers: xcode`

🤖 Generated with [Claude Code](https://claude.com/claude-code)